### PR TITLE
Added retries on 429 response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Change Log - @itwin/insights-client
 
 ## 0.5.0
-Wed, 31 May 2023
+Mon, 4 Jul 2023
 
-Minor
+### Minor
 - ### Changes to Interfaces
   - `EC3ConfigurationClient` `getConfigurations` return type has been corrected to match actual response.
     - `EC3Configuration` > `EC3ConfigurationMinimal`
+
+### Patches
+- Added handling of responses with status code 429 Too Many Requests. Now the client will retry such responses, delaying each retry by the amount of seconds specified in the Retry-After response header. A maximum of 3 attempts will be made per request.
+
 ## 0.4.0
 
 Thu, 3 Mar 2023

--- a/src/test/OperationsBase.test.ts
+++ b/src/test/OperationsBase.test.ts
@@ -84,6 +84,27 @@ describe("OperationsBase", () => {
     await expect(operationsBase.fetchData("url", {})).to.be.rejected;
   });
 
+  it("fetch retries on 429", async () => {
+    const fetchStub = sinon.stub(operationsBase, "fetch" as any);
+    const headers = new Headers();
+    headers.set("Retry-After", "1");
+    fetchStub.onFirstCall().resolves(new Response(null, { status: 429, headers }));
+    fetchStub.onSecondCall().resolves(new Response(null, { status: 204 }));
+
+    const response = await operationsBase.fetchJSON("url", {});
+    expect(response).to.not.be.undefined;
+  });
+
+  it("fetch has a maximum of 3 attempts for 429 responses", async () => {
+    const fetchStub = sinon.stub(operationsBase, "fetch" as any);
+    const headers = new Headers();
+    headers.set("Retry-After", "0");
+    fetchStub.resolves(new Response(null, { status: 429, headers }));
+
+    await expect(operationsBase.fetchJSON("url", {})).to.be.rejected;
+    expect(fetchStub.callCount).to.be.eq(3);
+  });
+
   it("createRequest", () => {
     let response: RequestInit;
     response = operationsBase.createRequest("GET", "5");


### PR DESCRIPTION
Amended the Changelog since the 0.5.0 was not published yet.
Added retries whenever 429 response is returned. A better solution would be to use something like https://www.npmjs.com/package/async-retry but I did not want to add additional dependency.