### PR TITLE
version bump and changelog fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # Change Log - @itwin/insights-client
 
+## 0.5.1
+Fri, 7 Jul 2023
+### Patches
+- Added handling of responses with status code 429 Too Many Requests. Now the client will retry such responses, delaying each retry by the amount of seconds specified in the Retry-After response header. A maximum of 3 attempts will be made per request.
+
 ## 0.5.0
-Mon, 4 Jul 2023
+Wed, 5 Jul 2023
 
 ### Minor
 - ### Changes to Interfaces
   - `EC3ConfigurationClient` `getConfigurations` return type has been corrected to match actual response.
     - `EC3Configuration` > `EC3ConfigurationMinimal`
-
-### Patches
-- Added handling of responses with status code 429 Too Many Requests. Now the client will retry such responses, delaying each retry by the amount of seconds specified in the Retry-After response header. A maximum of 3 attempts will be made per request.
 
 ## 0.4.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@itwin/insights-client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@itwin/insights-client",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/insights-client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Insights client for the iTwin platform",
   "main": "lib/cjs/insights-client.js",
   "module": "lib/esm/insights-client.js",


### PR DESCRIPTION
The insights-client publish step for 0.5.0 was approved unexpectedly while https://github.com/iTwin/insights-client/pull/34 was not yet merged and that PR had an assumption that 0.5.0 was not released yet. When I merged the PR the publish already happened, so now I need to update changelog and bump the version.