### PR TITLE
Changes in the MappingsClient to refer basePath passed as constructor parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @itwin/insights-client
 
+## 0.13.1
+Monday, 16 September, 2024
+### Patch
+- Changes in the `MappingsClient` to refer `basePath` passed as constructor parameter.
+
 ## 0.13.0
 Tuesday, 10 September, 2024
 ### Minor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/insights-client",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Insights client for the iTwin platform",
   "main": "lib/cjs/insights-client.js",
   "module": "lib/esm/insights-client.js",

--- a/src/grouping-and-mapping/clients/MappingsClient.ts
+++ b/src/grouping-and-mapping/clients/MappingsClient.ts
@@ -13,10 +13,11 @@ import { EntityListIteratorImpl } from "../../common/iterators/EntityListIterato
 import { getEntityCollectionPage } from "../../common/iterators/IteratorUtil";
 
 export class MappingsClient extends OperationsBase implements IMappingsClient {
-  private _baseUrl = `${this.basePath}/datasources/imodel-mappings`;
+  private readonly _baseUrl;
 
   constructor(basePath?: string) {
     super(basePath ?? GROUPING_AND_MAPPING_BASE_PATH);
+    this._baseUrl = `${basePath ?? GROUPING_AND_MAPPING_BASE_PATH}/datasources/imodel-mappings`;
   }
 
   public async createMapping(accessToken: AccessToken, mappingCreate: MappingCreate): Promise<Mapping> {


### PR DESCRIPTION
Currently, the MappingsClient doesn't consider basePath passed to constructor for _baseUrl and _groupingAndMappingBasePath. It assigns default basePath to these fields. It is fixed in this PR.

![image](https://github.com/user-attachments/assets/d478e0ba-2de6-4f63-a465-e4baef9f0868)
